### PR TITLE
Removes time_entry_mode for company, as it's not definied anymore

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -594,10 +594,6 @@ components:
           description: The configured display of durations, either `hhmm` or `decimal`
           type: string
           enum: [hhmm, decimal]
-        time_entry_mode:
-          description: The way how time is tracked, either `start_end` or `duration`. This setting changes how the [Time Entry] and [Timer] endpoints have to be used
-          type: string
-          enum: [start_end, duration]
         absence_requests_enabled:
           description: Whether or not absence requests module is enabled
           type: boolean


### PR DESCRIPTION
Hi there,

It looks like time_entry_mode is not valid anymore, as it's not definied in https://www.hakuna.ch/docs#company